### PR TITLE
Adds missing title

### DIFF
--- a/src/ens/enjx1/index.md
+++ b/src/ens/enjx1/index.md
@@ -33,7 +33,8 @@ l’informatique tient à sa capacité à décomposer tout problème en élémen
 procédures que l’on peut composer, combiner, enchaîner. Il s’agit d’une éducation à
 « ouvrir les boîtes noires » des objets numériques qui nous entourent pour en comprendre
 les rouages, et à tester les différentes manières d’envisager une solution.
-Environnement socio-technique
+
+### Environnement socio-technique
 Il s’agit de replacer l’objet abordé dans un contexte qui est spécifique, qu’il soit culturel,
 historique, géographique, économique, social ou personnel.
 


### PR DESCRIPTION
Adds the title marker in front of the second notion (that was collapsed inside the first one).

1. Ajoute de balises de titre manquantes

2. Correction de mise en page

3. Ajout d'une balise de titre devant un élément semblant clairement être par erreur mélangé dans un paragraphe précédent

4. @Lucile24 @vhaussau 