### PR TITLE
Lien relatifs dans README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,4 @@ Dans le cadre du [plan d'études romand pour l'enseignement de l'informatique au
 
 Ces ressources sont mises à disposition selon les termes de la <a rel="license" href="https://github.com/edunumsec2/book/blob/d44ad2d4a67c6e5e170b4146fb2914e0eed876fd/LICENCE.md">Licence Creative Commons Attribution - Pas d’Utilisation Commerciale - Partage dans les Mêmes Conditions 3.0</a>.
 
-<h2 align="center">
-  <a href="https://github.com/edunumsec2/book/blob/documentation/CONTRIBUTING.md">Contribuer</a>
-  <span> · </span>
-  <a href="https://github.com/edunumsec2/book/blob/documentation/CODE_OF_CONDUCT.md">Code de conduite</a>
-  <span> · </span>
-  <a href="https://github.com/edunumsec2/book/blob/documentation/GOVERNANCE.md">Gouvernance</a>
-  <span> · </span>
-  <a href="https://github.com/edunumsec2/book/blob/documentation/doc/comit%C3%A9.md">Comité</a>
-  <span> · </span>
-  <a href="https://discord.gg/b8qu79t6HQ">Discord</a>
-</h2>
+### [Installation](doc/installation.md) • [Contribuer](CONTRIBUTING.md)   • [Code de conduite](CODE_OF_CONDUCT.md)  • [Gouvernance](GOUVERNANCE.md)  • [Comité](doc/comite.md)  • [Discord](https://discord.gg/b8qu79t6HQ) 


### PR DESCRIPTION
Je propose d'ajouter un lien pour l'installation et de mettre des liens relatifs, plutôt des lien absolus sur github. Sinon ces liens se cassent en cas de fork. 
C'est ok pour vous, en particulier @elliotvaucher  et @gregoiregavin  ? 
