### PR TITLE
Modifies auto-build commands to improve performances

### DIFF
--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -50,14 +50,14 @@
 				{
 					"name": "Apprendre (auto-build)",
 					"color": "white",
-					"command": "source .env/bin/activate; kill -9 $(lsof -t -i:8000) 2> /dev/null; sphinx-autobuild src/appr build --watch src --open-browser -a --delay 1",
+					"command": "source .env/bin/activate; kill -9 $(lsof -t -i:8000) 2> /dev/null; sphinx-autobuild src/appr build --watch src --open-browser -j auto --delay 1",
 					"cwd": "${workspaceFolder}",
 					"singleInstance": true,
 				},
 				{
 					"name": "Enseigner (auto-build)",
 					"color": "white",
-					"command": "source .env/bin/activate; kill -9 $(lsof -t -i:8000) 2> /dev/null; sphinx-autobuild src/ens build --watch src --open-browser -a --delay 1",
+					"command": "source .env/bin/activate; kill -9 $(lsof -t -i:8000) 2> /dev/null; sphinx-autobuild src/ens build --watch src --open-browser -j auto --delay 1",
 					"cwd": "${workspaceFolder}",
 					"singleInstance": true,
 				},


### PR DESCRIPTION
### Comportement actuel
L'action "Enseigner (auto-build)" (idem pour "Apprendre (auto-build)") du fichier [workspace.code-workspace](https://github.com/edunumsec2/book/blob/7f4b699b659fad6a48ca47ab53988fb7306eeefd/workspace.code-workspace#L60) effectue la commande suivante `source .env/bin/activate; kill -9 $(lsof -t -i:8000) 2> /dev/null; sphinx-autobuild src/ens build --watch src --open-browser -a --delay 1`

L'option `-a`, d'après [la documentation spinx](https://www.sphinx-doc.org/en/master/man/sphinx-build.html)  force la réécriture de tous les fichiers, ce qui rend le build plus long (plusieurs secondes), or je trouve que l'auto-build est plus intéressant avec un build rapide étant donné le relancement du build à chaque modification dans l'éditeur. 

### Proposition
La PR proposée permet ainsi de réduire le temps de build en utilisant les boutons du workspace en : 
- retirant l'option `-a`, ce qui évite de réécrire des fichiers d'output s'ils ont déjà été écrits et qu'aucune modification n'est nécessaire
- ajoutant l'option `-j auto` qui permet de paralléliser les tâches du build pour les machines ayant plusieurs core
### Temps de build sur ma machine (MacOS, M1 2020)
| Commande initiale | Commande initiale sans l'option `-a` | Commande initiale sans l'option `-a` et avec `-j auto` |
|--------|--------|--------|
| 22s | 7s | 7s |

(sur MacOS, un avertissement prévient que l'option `-j auto` est désactivée, voir : https://github.com/sphinx-doc/sphinx/issues/6803, ce qui explique les temps identiques. Les utilisateur·trice·s Windows et Linux pourraient toutefois en bénéficier)